### PR TITLE
Step10. 시나리오별 동시성 테스트 구현 및 회고록

### DIFF
--- a/initData.sql
+++ b/initData.sql
@@ -1,0 +1,18 @@
+insert into user(user_id, deposit) values('test', 10000);
+
+INSERT INTO concert (concert_id, show_date, concert_name, host)
+VALUES (NULL, '2025-01-16 19:30:00', 'CNBLUE CONCERT', 'CNBLUE');
+
+
+INSERT INTO concert_seat (price, seat_number, concert_id, hold_expired_at, seat_id, seat_status)
+VALUES
+    (10000.00, 1, 1, '2025-01-16 20:00:00', NULL, 'AVAILABLE'),
+    (10000.00, 2, 1, '2025-01-16 20:00:00', NULL, 'AVAILABLE'),
+    (10000.00, 3, 1, '2025-01-16 20:00:00', NULL, 'AVAILABLE'),
+    (10000.00, 4, 1, '2025-01-16 20:00:00', NULL, 'AVAILABLE'),
+    (10000.00, 5, 1, '2025-01-16 20:00:00', NULL, 'AVAILABLE'),
+    (10000.00, 6, 1, '2025-01-16 20:00:00', NULL, 'AVAILABLE'),
+    (10000.00, 7, 1, '2025-01-16 20:00:00', NULL, 'AVAILABLE'),
+    (10000.00, 8, 1, '2025-01-16 20:00:00', NULL, 'AVAILABLE'),
+    (10000.00, 9, 1, '2025-01-16 20:00:00', NULL, 'AVAILABLE'),
+    (10000.00, 10, 1, '2025-01-16 20:00:00', NULL, 'AVAILABLE');

--- a/src/main/java/kr/hhplus/be/server/module/auth/domain/entity/WaitListToken.java
+++ b/src/main/java/kr/hhplus/be/server/module/auth/domain/entity/WaitListToken.java
@@ -44,7 +44,7 @@ public class WaitListToken {
 
 
     public boolean isTokenActive() {
-        if(StringUtils.equals(this.status.toString(), TokenStatus.ACTIVE.name())) {
+        if(StringUtils.equals(this.status.name(), TokenStatus.ACTIVE.name())) {
             return true;
         }
         return false;

--- a/src/main/java/kr/hhplus/be/server/module/auth/domain/repository/WaitListTokenRepository.java
+++ b/src/main/java/kr/hhplus/be/server/module/auth/domain/repository/WaitListTokenRepository.java
@@ -13,6 +13,8 @@ public interface WaitListTokenRepository {
 
     WaitListToken findByToken(String token);
 
+    WaitListToken findByTokenWithLock(String token);
+
     List<WaitListToken> findByStatusOrderByLastIssuedAtAsc(TokenStatus tokenStatus);
 
     List<WaitListToken> findByStatusNotOrderByLastIssuedAtAsc(TokenStatus tokenStatus, Pageable pageable);

--- a/src/main/java/kr/hhplus/be/server/module/auth/domain/service/WaitListTokenService.java
+++ b/src/main/java/kr/hhplus/be/server/module/auth/domain/service/WaitListTokenService.java
@@ -64,8 +64,9 @@ public class WaitListTokenService {
         return true;
     }
 
+    @Transactional
     public WaitListToken getWaitListTokenByToken(String token) throws Exception {
-        WaitListToken waitListToken = waitListTokenRepository.findByToken(token);
+        WaitListToken waitListToken = waitListTokenRepository.findByTokenWithLock(token);
 
         if(waitListToken == null || StringUtils.equals(waitListToken.getStatus().toString(), TokenStatus.EXPIRED.name())) {
             throw new ApiException(ErrorCode.NOT_FOUND_WAITLIST_TOKEN);

--- a/src/main/java/kr/hhplus/be/server/module/auth/infrastructure/repository/WaitListTokenJpaRepository.java
+++ b/src/main/java/kr/hhplus/be/server/module/auth/infrastructure/repository/WaitListTokenJpaRepository.java
@@ -1,15 +1,23 @@
 package kr.hhplus.be.server.module.auth.infrastructure.repository;
 
+import jakarta.persistence.LockModeType;
 import kr.hhplus.be.server.module.auth.domain.code.TokenStatus;
 import kr.hhplus.be.server.module.auth.domain.entity.WaitListToken;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface WaitListTokenJpaRepository extends JpaRepository<WaitListToken, Long> {
     WaitListToken findByUserId(String userId);
     WaitListToken findByToken(String token);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT w FROM WaitListToken w WHERE w.token = :token")
+    WaitListToken findByTokenWithLock(@Param("token") String token);
 
     List<WaitListToken> findByStatusOrderByLastIssuedAtAsc(TokenStatus tokenStatus);
     List<WaitListToken> findByStatusNotOrderByLastIssuedAtAsc(TokenStatus tokenStatus, Pageable pageable);

--- a/src/main/java/kr/hhplus/be/server/module/auth/infrastructure/repository/impl/JpaWaitListTokenRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/module/auth/infrastructure/repository/impl/JpaWaitListTokenRepositoryImpl.java
@@ -36,6 +36,11 @@ public class JpaWaitListTokenRepositoryImpl implements WaitListTokenRepository {
     }
 
     @Override
+    public WaitListToken findByTokenWithLock(String token) {
+        return waitListTokenJpaRepository.findByTokenWithLock(token);
+    }
+
+    @Override
     public List<WaitListToken> findByStatusOrderByLastIssuedAtAsc(TokenStatus tokenStatus) {
         return waitListTokenJpaRepository.findByStatusOrderByLastIssuedAtAsc(tokenStatus);
     }

--- a/src/main/java/kr/hhplus/be/server/module/concert/application/facade/ConcertFacade.java
+++ b/src/main/java/kr/hhplus/be/server/module/concert/application/facade/ConcertFacade.java
@@ -46,13 +46,14 @@ public class ConcertFacade implements ConcertUsecase {
         LocalDateTime expiredAt = LocalDateTime.now().plusMinutes(5);
 
         //좌석 테이블의 상태값과 선점 만료 시간 업데이트
-        concertService.chageStatusToTempAssigned(seatId, expiredAt);
+        ConcertSeat seat = concertService.changeStatusToTempAssigned(seatId, expiredAt);
 
         //토큰의 최종 갱신 시간 업데이트
         waitListTokenService.updateTokenTime(token);
 
         //예약 테이블에 row 추가
-        ConcertReservation reservation = concertService.reserveSeatByUser(seatId, userId, expiredAt);
+        ConcertReservation reservation = concertService.reserveSeatByUser(seat.getConcertId(), seatId, userId, expiredAt);
+
         return ConcertReservationResponseDTO.fromEntity(reservation);
     }
 }

--- a/src/main/java/kr/hhplus/be/server/module/concert/domain/entity/ConcertReservation.java
+++ b/src/main/java/kr/hhplus/be/server/module/concert/domain/entity/ConcertReservation.java
@@ -1,6 +1,8 @@
 package kr.hhplus.be.server.module.concert.domain.entity;
 
 import jakarta.persistence.*;
+import kr.hhplus.be.server.module.common.error.code.ErrorCode;
+import kr.hhplus.be.server.module.common.error.exception.ApiException;
 import kr.hhplus.be.server.module.concert.domain.code.ReservationStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -61,6 +63,9 @@ public class ConcertReservation {
     }
 
     public void changeStatusToPaid() {
+        if(this.status != ReservationStatus.RESERVED) {
+            throw new ApiException(ErrorCode.REQUIRE_RESERVATION);
+        }
         this.status = ReservationStatus.PAID;
     }
 }

--- a/src/main/java/kr/hhplus/be/server/module/concert/domain/entity/ConcertSeat.java
+++ b/src/main/java/kr/hhplus/be/server/module/concert/domain/entity/ConcertSeat.java
@@ -48,11 +48,8 @@ public class ConcertSeat {
         }
 
         //임시 배정된 좌석의 경우 좌석 선점 시간이 만료 되지 않았다면
-        if(StringUtils.equals(this.status.toString(), SeatStatus.TEMP_ASSIGNED.name())
-                && isSeatReservationValidTime ()) {
-            return true;
-        }
-
+//        if(StringUtils.equals(this.status.toString(), SeatStatus.TEMP_ASSIGNED.name())
+//                && isSeatReservationValidTime ()) {
         return false;
     }
 

--- a/src/main/java/kr/hhplus/be/server/module/concert/domain/repository/ConcertReservationRepository.java
+++ b/src/main/java/kr/hhplus/be/server/module/concert/domain/repository/ConcertReservationRepository.java
@@ -9,6 +9,8 @@ public interface ConcertReservationRepository {
     ConcertReservation save(ConcertReservation allocation);
 
     Optional<ConcertReservation> findById(long reservationId);
+    Optional<ConcertReservation> findByIdWithLock(long reservationId);
     Optional<ConcertReservation> findBySeatId(long seatId);
     List<ConcertReservation> findByConcertId(long concertId);
+
 }

--- a/src/main/java/kr/hhplus/be/server/module/concert/domain/repository/ConcertSeatRepository.java
+++ b/src/main/java/kr/hhplus/be/server/module/concert/domain/repository/ConcertSeatRepository.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 
 public interface ConcertSeatRepository {
     Optional<ConcertSeat> findById(long seatId);
+    Optional<ConcertSeat> findByIdWithLock(long seatId);
     ConcertSeat save(ConcertSeat seat);
 
     List<ConcertSeat> findByConcertIdAndStatus(long concertId, SeatStatus seatStatus);

--- a/src/main/java/kr/hhplus/be/server/module/concert/infrastructure/repository/ConcertReservationJpaRepository.java
+++ b/src/main/java/kr/hhplus/be/server/module/concert/infrastructure/repository/ConcertReservationJpaRepository.java
@@ -1,12 +1,19 @@
 package kr.hhplus.be.server.module.concert.infrastructure.repository;
 
+import jakarta.persistence.LockModeType;
 import kr.hhplus.be.server.module.concert.domain.entity.ConcertReservation;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface ConcertReservationJpaRepository extends JpaRepository<ConcertReservation, Long> {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT cr FROM ConcertReservation cr WHERE cr.reservationId = :reservationId")
+    Optional<ConcertReservation> findByIdWithLock(@Param("reservationId")long reservationId);
     Optional<ConcertReservation> findBySeatId(long seatId);
     List<ConcertReservation> findByConcertId(long concertId);
 }

--- a/src/main/java/kr/hhplus/be/server/module/concert/infrastructure/repository/ConcertSeatJpaRepository.java
+++ b/src/main/java/kr/hhplus/be/server/module/concert/infrastructure/repository/ConcertSeatJpaRepository.java
@@ -1,11 +1,20 @@
 package kr.hhplus.be.server.module.concert.infrastructure.repository;
 
+import jakarta.persistence.LockModeType;
 import kr.hhplus.be.server.module.concert.domain.code.SeatStatus;
 import kr.hhplus.be.server.module.concert.domain.entity.ConcertSeat;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ConcertSeatJpaRepository extends JpaRepository<ConcertSeat, Long> {
     List<ConcertSeat> findByConcertIdAndStatus(long concertId, SeatStatus seatStatus);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT cs FROM ConcertSeat cs WHERE cs.id = :seatId")
+    Optional<ConcertSeat> findByIdWithLock(@Param("seatId")long seatId);
 }

--- a/src/main/java/kr/hhplus/be/server/module/concert/infrastructure/repository/impl/JpaConcertReservationRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/module/concert/infrastructure/repository/impl/JpaConcertReservationRepositoryImpl.java
@@ -25,6 +25,11 @@ public class JpaConcertReservationRepositoryImpl implements ConcertReservationRe
     }
 
     @Override
+    public Optional<ConcertReservation> findByIdWithLock(long reservationId) {
+        return concertReservationJpaRepository.findByIdWithLock(reservationId);
+    }
+
+    @Override
     public Optional<ConcertReservation> findBySeatId(long seatId) {
         return concertReservationJpaRepository.findBySeatId(seatId);
     }

--- a/src/main/java/kr/hhplus/be/server/module/concert/infrastructure/repository/impl/JpaConcertSeatRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/module/concert/infrastructure/repository/impl/JpaConcertSeatRepositoryImpl.java
@@ -21,12 +21,16 @@ public class JpaConcertSeatRepositoryImpl implements ConcertSeatRepository {
     }
 
     @Override
+    public Optional<ConcertSeat> findByIdWithLock(long seatId) { return concertSeatJpaRepository.findByIdWithLock(seatId);
+    }
+
+    @Override
     public ConcertSeat save(ConcertSeat seat) {
         return concertSeatJpaRepository.save(seat);
     }
 
     @Override
-    public List<ConcertSeat> findByConcertIdAndStatusWithLock(long concertId, SeatStatus seatStatus) {
-        return concertSeatJpaRepository.findByConcertIdAndStatusWithLock(concertId, seatStatus);
+    public List<ConcertSeat> findByConcertIdAndStatus(long concertId, SeatStatus seatStatus) {
+        return concertSeatJpaRepository.findByConcertIdAndStatus(concertId, seatStatus);
     }
 }

--- a/src/main/java/kr/hhplus/be/server/module/payment/application/facade/PaymentFacade.java
+++ b/src/main/java/kr/hhplus/be/server/module/payment/application/facade/PaymentFacade.java
@@ -1,6 +1,5 @@
 package kr.hhplus.be.server.module.payment.application.facade;
 
-import jakarta.transaction.Transactional;
 import kr.hhplus.be.server.module.auth.domain.service.WaitListTokenService;
 import kr.hhplus.be.server.module.common.error.code.ErrorCode;
 import kr.hhplus.be.server.module.common.error.exception.ApiException;
@@ -21,7 +20,6 @@ public class PaymentFacade implements PaymentUsecase {
     private final PaymentService paymentService;
     private final WaitListTokenService waitListTokenService;
 
-    @Transactional
     @Override
     public void payForConcert(String userId, String token, long reservationId) throws Exception {
         //예약이 유효한 지 확인

--- a/src/test/java/kr/hhplus/be/server/module/auth/application/facade/WaitListTokenFacadeConcurrencyTest.java
+++ b/src/test/java/kr/hhplus/be/server/module/auth/application/facade/WaitListTokenFacadeConcurrencyTest.java
@@ -1,0 +1,105 @@
+package kr.hhplus.be.server.module.auth.application.facade;
+
+import kr.hhplus.be.server.module.auth.application.scheduler.WaitListTokenScheduler;
+import kr.hhplus.be.server.module.auth.application.usecase.WaitListTokenUsecase;
+import kr.hhplus.be.server.module.auth.domain.code.TokenStatus;
+import kr.hhplus.be.server.module.auth.domain.entity.WaitListToken;
+import kr.hhplus.be.server.module.auth.domain.policy.WaitListTokenPolicy;
+import kr.hhplus.be.server.module.auth.domain.repository.WaitListTokenRepository;
+import kr.hhplus.be.server.module.auth.domain.service.WaitListTokenService;
+import kr.hhplus.be.server.module.user.domain.entity.User;
+import kr.hhplus.be.server.module.user.domain.repository.UserRepository;
+import kr.hhplus.be.server.test.base.BaseIntegretionTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class WaitListTokenFacadeConcurrencyTest extends BaseIntegretionTest {
+    @Autowired
+    private WaitListTokenUsecase waitListTokenUsecase;
+    @Autowired
+    private WaitListTokenRepository waitListTokenRepository;
+    @Autowired
+    private UserRepository userRepository;
+    @Mock
+    private WaitListTokenPolicy waitListTokenPolicy;
+    @InjectMocks
+    private WaitListTokenService waitListTokenService;
+    @InjectMocks
+    private WaitListTokenScheduler waitListTokenScheduler;
+
+    User givenUser;
+
+    String userId = "test";
+    String token = "test:1";
+
+    @BeforeEach
+    void init() {
+        User user = User.builder()
+                .id(userId)
+                .deposit(50_000)
+                .build();
+
+        givenUser = userRepository.save(user);
+
+        WaitListToken waitListToken = WaitListToken.builder()
+                .userId(userId)
+                .token(token)
+                .build();
+
+        waitListTokenRepository.save(waitListToken);
+
+    }
+
+    @Test
+    void 사용자_20명이_요청을_하면_10명만_액세스한다() throws Exception {
+        //given
+        int threadCount = 20;
+        int capacity = 10;
+        when(waitListTokenPolicy.getMaxCapacity()).thenReturn(capacity);
+
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        //when
+        for (int i = 0; i < threadCount; i++) {
+            String userId = "user" + i;
+            executorService.execute(() -> {
+                try {
+                    waitListTokenUsecase.issueToken(userId);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();  // 모든 스레드가 완료될 때까지 대기
+        executorService.shutdown();
+
+        Thread.sleep(5000);
+
+        //then
+
+        //토큰 값 확인
+        List<WaitListToken> tokens = waitListTokenRepository.findByStatusOrderByLastIssuedAtAsc(TokenStatus.ACTIVE);
+        assertThat(tokens).isNotNull();
+        assertThat(tokens.size()).isEqualTo(capacity);
+    }
+
+}

--- a/src/test/java/kr/hhplus/be/server/module/concert/application/facade/ConcertFacadeConcurrencyTest.java
+++ b/src/test/java/kr/hhplus/be/server/module/concert/application/facade/ConcertFacadeConcurrencyTest.java
@@ -1,0 +1,176 @@
+package kr.hhplus.be.server.module.concert.application.facade;
+
+import kr.hhplus.be.server.module.auth.domain.code.TokenStatus;
+import kr.hhplus.be.server.module.auth.domain.entity.WaitListToken;
+import kr.hhplus.be.server.module.auth.domain.repository.WaitListTokenRepository;
+import kr.hhplus.be.server.module.concert.application.usecase.ConcertUsecase;
+import kr.hhplus.be.server.module.concert.domain.code.ReservationStatus;
+import kr.hhplus.be.server.module.concert.domain.code.SeatStatus;
+import kr.hhplus.be.server.module.concert.domain.entity.Concert;
+import kr.hhplus.be.server.module.concert.domain.entity.ConcertReservation;
+import kr.hhplus.be.server.module.concert.domain.entity.ConcertSeat;
+import kr.hhplus.be.server.module.concert.domain.repository.ConcertRepository;
+import kr.hhplus.be.server.module.concert.domain.repository.ConcertReservationRepository;
+import kr.hhplus.be.server.module.concert.domain.repository.ConcertSeatRepository;
+import kr.hhplus.be.server.test.base.BaseIntegretionTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class ConcertFacadeConcurrencyTest extends BaseIntegretionTest {
+    @Autowired
+    private ConcertUsecase concertUsecase;
+    @Autowired
+    private ConcertFacade concertFacade;
+    @Autowired
+    private ConcertRepository concertRepository;
+    @Autowired
+    private ConcertSeatRepository concertSeatRepository;
+    @Autowired
+    private ConcertReservationRepository concertReservationRepository;
+    @Autowired
+    private WaitListTokenRepository waitListTokenRepository;
+
+    Concert givenConcert;
+
+    String userId = "test";
+    String token = "test:1";
+
+    @BeforeEach
+    void init() {
+        Concert concert = Concert.builder()
+                .concertName("씨엔블루 콘서트")
+                .host("씨엔블루")
+                .showDate(LocalDateTime.of(2025,10,7, 10,30,0))
+                .build();
+
+        givenConcert = concertRepository.save(concert);
+
+
+        for(int i= 1; i<=10; i++) {
+            ConcertSeat seat = ConcertSeat.builder()
+                    .concertId(givenConcert.getId())
+                    .number(i)
+                    .status(SeatStatus.AVAILABLE)
+                    .price(10_000)
+                    .build();
+
+            concertSeatRepository.save(seat);
+
+            WaitListToken waitListToken = WaitListToken.builder()
+                    .userId("user" + i)
+                    .token("token" + i)
+                    .status(TokenStatus.ACTIVE)
+                    .build();
+            waitListTokenRepository.save(waitListToken);
+        }
+
+
+    }
+
+    @Test
+    void 동시에_10명이_하나의_좌석을_예약한_경우_좌석은_한사람에게만_예약된다() throws Exception {
+        //given
+        int threadCount = 10;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        long seatId = 1;
+
+        //when
+        for (int i = 0; i < threadCount; i++) {
+            int finalI = i+1;
+            String userId = "user" + finalI;
+            String token = "token" + finalI;
+            executorService.execute(() -> {
+                try {
+                     concertUsecase.reserveSeat(userId, (long) seatId, token);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();  // 모든 스레드가 완료될 때까지 대기
+        executorService.shutdown();
+
+        //then
+        //예약 상태 값 확인
+        ConcertReservation reservation = concertReservationRepository.findBySeatId(seatId).get();
+        assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.RESERVED);
+
+        //좌석 상태 값 확인
+        Optional<ConcertSeat> seat = concertSeatRepository.findById(seatId);
+        assertThat(seat).isNotNull();
+        assertThat(seat.get().getConcertId()).isEqualTo(reservation.getConcertId());
+        assertThat(seat.get().getStatus()).isEqualTo(SeatStatus.TEMP_ASSIGNED);
+
+        //해당 유저의 토큰이 살아 있는지 확인
+        WaitListToken token = waitListTokenRepository.findByUserId(reservation.getUserId());
+        assertThat(token.isTokenActive()).isTrue();
+    }
+
+    @Test
+    void 동시에_10명의_사용자가_각자_다른_좌석을_예매하면_모두_성공한다() throws Exception {
+        //given
+        int threadCount = 10;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        //when
+        for (int i = 0; i < threadCount; i++) {
+            int finalI = i+1;
+            String tempUserId = "user" + finalI;
+            String token = "token" + finalI;
+            executorService.execute(() -> {
+                try {
+                    concertUsecase.reserveSeat(tempUserId, (long) finalI, token);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();  // 모든 스레드가 완료될 때까지 대기
+        executorService.shutdown();
+
+        //then
+
+        List<ConcertReservation> reservations = concertReservationRepository.findByConcertId(givenConcert.getId());
+
+        assertThat(reservations).isNotNull();
+        assertThat(reservations.size()).isEqualTo(threadCount);
+
+        //유저 별 예약 내용 확인
+        for(ConcertReservation reservation : reservations) {
+            String userId = reservation.getUserId();
+            long seatId = reservation.getSeatId();
+
+            //예약 상태 값 확인
+            assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.RESERVED);
+
+            //좌석 상태 값 확인
+            Optional<ConcertSeat> seat = concertSeatRepository.findById(seatId);
+            assertThat(seat).isNotNull();
+            assertThat(seat.get().getConcertId()).isEqualTo(reservation.getConcertId());
+            assertThat(seat.get().getStatus()).isEqualTo(SeatStatus.TEMP_ASSIGNED);
+        }
+    }
+}

--- a/src/test/java/kr/hhplus/be/server/module/concert/domain/entity/ConcertSeatTest.java
+++ b/src/test/java/kr/hhplus/be/server/module/concert/domain/entity/ConcertSeatTest.java
@@ -23,20 +23,13 @@ class ConcertSeatTest {
     }
 
     @Test
-    void 좌석이_AVAILABLE상태가_아닐때_예약이_불가능하다() {
+    void 좌석이_결제됐다면_예약이_불가능하다() {
         //given
-        ConcertSeat tempAssignedSeat = ConcertSeat.builder()
-                .status(SeatStatus.TEMP_ASSIGNED)
-                .build();
-
         ConcertSeat reservedSeat = ConcertSeat.builder()
                 .status(SeatStatus.PAID)
                 .build();
 
         //then
-        assertFalse(tempAssignedSeat.isSeatAvailable());
-        assertTrue(tempAssignedSeat.isSeatOccupied());
-
         assertFalse(reservedSeat.isSeatAvailable());
         assertTrue(reservedSeat.isSeatOccupied());
     }

--- a/src/test/java/kr/hhplus/be/server/module/payment/application/facade/PaymentFacadeConcurrencyTest.java
+++ b/src/test/java/kr/hhplus/be/server/module/payment/application/facade/PaymentFacadeConcurrencyTest.java
@@ -1,0 +1,163 @@
+package kr.hhplus.be.server.module.payment.application.facade;
+
+import kr.hhplus.be.server.module.auth.domain.entity.WaitListToken;
+import kr.hhplus.be.server.module.auth.domain.repository.WaitListTokenRepository;
+import kr.hhplus.be.server.module.auth.domain.service.WaitListTokenService;
+import kr.hhplus.be.server.module.concert.application.facade.ConcertFacade;
+import kr.hhplus.be.server.module.concert.application.usecase.ConcertUsecase;
+import kr.hhplus.be.server.module.concert.domain.code.ReservationStatus;
+import kr.hhplus.be.server.module.concert.domain.code.SeatStatus;
+import kr.hhplus.be.server.module.concert.domain.entity.Concert;
+import kr.hhplus.be.server.module.concert.domain.entity.ConcertReservation;
+import kr.hhplus.be.server.module.concert.domain.entity.ConcertSeat;
+import kr.hhplus.be.server.module.concert.domain.repository.ConcertRepository;
+import kr.hhplus.be.server.module.concert.domain.repository.ConcertReservationRepository;
+import kr.hhplus.be.server.module.concert.domain.repository.ConcertSeatRepository;
+import kr.hhplus.be.server.module.concert.domain.service.ConcertService;
+import kr.hhplus.be.server.module.payment.application.usecase.PaymentUsecase;
+import kr.hhplus.be.server.module.payment.domain.entity.Payment;
+import kr.hhplus.be.server.module.payment.domain.repository.PaymentRepository;
+import kr.hhplus.be.server.module.payment.domain.service.PaymentService;
+import kr.hhplus.be.server.module.user.domain.entity.User;
+import kr.hhplus.be.server.module.user.domain.repository.UserRepository;
+import kr.hhplus.be.server.module.user.domain.service.UserDepositService;
+import kr.hhplus.be.server.test.base.BaseIntegretionTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class PaymentFacadeConcurrencyTest extends BaseIntegretionTest {
+    @Autowired
+    private ConcertFacade concertFacade;
+    @Autowired
+    private ConcertRepository concertRepository;
+    @Autowired
+    private ConcertSeatRepository concertSeatRepository;
+    @Autowired
+    private ConcertReservationRepository concertReservationRepository;
+    @Autowired
+    private WaitListTokenRepository waitListTokenRepository;
+    @Autowired
+    private PaymentUsecase paymentUsecase;
+    @Autowired
+    private ConcertUsecase concertUsecase;
+    @Autowired
+    private ConcertService concertService;
+    @Autowired
+    private UserDepositService userDepositService;
+    @Autowired
+    private PaymentService paymentService;
+    @Autowired
+    private WaitListTokenService waitListTokenService;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private PaymentRepository paymentRepository;
+
+    Concert givenConcert;
+    ConcertSeat givenSeat;
+    User givenUser;
+    WaitListToken givenToken;
+
+    String userId = "test";
+    String token = "test:1";
+
+    @BeforeEach
+    void init() {
+        User user = User.builder()
+                .id(userId)
+                .deposit(50_000)
+                .build();
+
+        givenUser = userRepository.save(user);
+
+        WaitListToken waitListToken = WaitListToken.builder()
+                .userId(userId)
+                .token(token)
+                .build();
+        givenToken = waitListTokenRepository.save(waitListToken);
+
+        Concert concert = Concert.builder()
+                .concertName("씨엔블루 콘서트")
+                .host("씨엔블루")
+                .showDate(LocalDateTime.of(2025,10,7, 10,30,0))
+                .build();
+
+        givenConcert = concertRepository.save(concert);
+
+        ConcertSeat seat = ConcertSeat.builder()
+                .concertId(givenConcert.getId())
+                .number(1)
+                .status(SeatStatus.AVAILABLE)
+                .price(10_000)
+                .build();
+
+        givenSeat = concertSeatRepository.save(seat);
+    }
+
+    @Test
+    void 한_사람이_결제를_3번_호출해도_한번만_결제된다() throws Exception {
+        //given
+        int threadCount = 3;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        long reservationId = 1;
+
+        concertUsecase.reserveSeat(userId, givenSeat.getId(), givenToken.getToken());
+
+        //when
+        for (int i = 0; i < threadCount; i++) {
+            executorService.execute(() -> {
+                try {
+                    paymentUsecase.payForConcert(userId, givenToken.getToken(), reservationId);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();  // 모든 스레드가 완료될 때까지 대기
+        executorService.shutdown();
+
+        //then
+        //예약 상태 값 확인
+        Optional<ConcertReservation> reservation = concertReservationRepository.findById(reservationId);
+        assertThat(reservation.get().getStatus()).isEqualTo(ReservationStatus.PAID);
+
+        //좌석 상태 값 확인
+        long seatId = reservation.get().getSeatId();
+        Optional<ConcertSeat> seat = concertSeatRepository.findById(seatId);
+        assertThat(seat).isNotNull();
+        assertThat(seat.get().getConcertId()).isEqualTo(reservation.get().getConcertId());
+        assertThat(seat.get().getStatus()).isEqualTo(SeatStatus.PAID);
+
+        //유저 잔액 차감 확인
+        User user = userRepository.findById(userId).get();
+        assertThat(user).isNotNull();
+        assertThat(user.getDeposit()).isEqualTo(givenUser.getDeposit() - givenSeat.getPrice());
+
+        //결제 데이터 저장 됐는지 확인
+        Payment payment = paymentRepository.findByUserIdAndReservationId(userId, reservation.get().getReservationId());
+        assertThat(payment).isNotNull();
+
+        //해당 유저의 토큰이 만료됐는지 확인
+        WaitListToken token = waitListTokenRepository.findByUserId(reservation.get().getUserId());
+        assertThat(token.isTokenActive()).isFalse();
+    }
+
+}


### PR DESCRIPTION
## **커밋 링크**
**동시성 테스트**
- 대기열 토큰 메서드 수정 및 동시성 테스트: d88ab35
- 콘서트 예약 메서드 수정 및 동시성 테스트: f39e7ce, c01ee90
- 결제메서드 수정 및 동시성 테스트: 45de97f

<br>

---

<br>

## **회고록**

지난 3주간 대기열 구현이 포함된 콘서트 프로젝트를 진행하였습니다. 콘서트와 이커머스라는 주제 중 선택할 수 있었는데, 저는 주제의 요구사항 중 콘서트의 대기열을 구현하는 내용이 흥미로워 콘서트를 선택하였습니다. 처음에는 쉽게 생각하고 도전하였지만, 과제를 진행하면서 예상보다 어려운 점이 많아 많은 고민과 학습의 시간이 필요했습니다.

**첫째 주: 요구사항 정립**
첫 주는 요구사항을 명확히 정립하는 것을 배웠습니다. 주어진 요구사항에서 모호한 부분을 캐치하고, 그것을 구체화하는 과정에서 요구사항을 정립해 나갔습니다. 이 과정에서 시퀀스 다이어그램과 ERD를 설계하며 프로세스를 시각화했습니다. 처음에는 시퀀스 다이어그램과 플로우 차트의 차이를 몰라 시퀀스 다이어그램을 플로우 차트처럼 작성하거나, 시퀀스 다이어그램과 ERD 작성 규칙에 익숙하지 않아 개념부터 배우는데 오래 걸렸습니다. 또한, 요구사항 정립보다는 개발에 더 집중했던 경험 때문인지 요구사항을 대충 정하고 문서 작성을 시작하게 되어 습관 잡기가 쉽지 않았습니다. 

**둘째 주: 비즈니스 로직 개발**
둘째 주는 Mock API와 비즈니스 로직 구현에 집중하였습니다. 실무의 협업 환경을 생각하며 개발이 다 되지 않더라도 협업이 가능하게끔 먼저 Mock API를 만들었습니다. 또한, 비즈니스 로직을 작성하면서 대기열 로직을 구현하다 보니 전 주에는 생각지도 못했던 스케줄러 프로세스가 필요했습니다. 급하게 스케줄러 다이어그램을 추가했습니다. 원래 이렇게 예상치도 못했던 요소가 튀어나오는 게 실무에서는 평범하니까요.

**셋째 주: 로깅과 동시성 테스트**
셋째 주는 Logback을 이용해 로깅을 구현했습니다. 인터페이스와 필터 기능을 추가했습니다. 요즘에는 필터와 인터페이스의 기능 구별이 많이 없어졌다고 들었습니다. 저는 필터에는 요청 API에 대한 로그를 남기고, 인터페이스에서는 특정 URL에 접속하면 대기열 토큰을 발급받고 검증하는 로직을 구현했습니다. 또한 동시성 테스트를 진행하면서 Lock에 대한 정의를 한 번 더 되짚을 수 있었습니다.

요구사항 정의부터 API 구현, 동시성 테스트까지 짧다면 짧고 길다면 긴 3주 동안 하나의 주제로 달려왔습니다. 아직 부족한 것이 많아 시간이 날 때마다 틈틈이 공부해야겠다고 다짐하지만, 회사 업무와 병행하게 되니 과제 구현에 급급해 그때그때 필요한 부분만 후다닥 공부하고 구현하고 있습니다. 다음 주 긴 설 연휴 동안 계획을 잡고 지난 배운 내용을 복습하며 다시 한번 제 것으로 만들어 보도록 하겠습니다.