### PR TITLE
Step16. 트랜잭션 분리 설계 보고서 작성 및 이벤트 발행으로 mockAPI 호출

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@
 
 [쿼리 수행 속도 개선(Feat. Index)](https://github.com/nacoon53/ticketing-service-api/wiki/7.-%EC%BF%BC%EB%A6%AC-%EC%88%98%ED%96%89-%EC%86%8D%EB%8F%84-%EA%B0%9C%EC%84%A0(Feat.-Index))
 
+[트랜잭션 분리 설계(Feat. MSA 설계)](https://www.notion.so/8-Feat-MSA-1996db2e3ea180c1a02ce52888f2761f?showMoveTo=true&saveParent=true)
+
 ## API 명세서
 [API 명세서 - SwaggerHub 링크](https://app.swaggerhub.com/apis-docs/nakyoungoh/concert_reservation/1.0.0#/%EC%BD%98%EC%84%9C%ED%8A%B8%20API/getAvailableSeats)
 ![img.png](/docs/APISpec_v1.png)

--- a/src/main/java/kr/hhplus/be/server/ServerApplication.java
+++ b/src/main/java/kr/hhplus/be/server/ServerApplication.java
@@ -4,8 +4,10 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.web.servlet.ServletComponentScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableAsync
 @EnableJpaAuditing
 @EnableScheduling
 @ServletComponentScan

--- a/src/main/java/kr/hhplus/be/server/dataplatformModule/DataPlatform.java
+++ b/src/main/java/kr/hhplus/be/server/dataplatformModule/DataPlatform.java
@@ -1,0 +1,14 @@
+package kr.hhplus.be.server.dataplatformModule;
+
+import kr.hhplus.be.server.module.externalApi.dataplatform.dto.event.ReservationEvent;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class DataPlatform {
+    public void receivedReservationData(ReservationEvent event) {
+        log.info("Received reservation data - userId: {}, seatId: {}", event.getUserId(), event.getSeatId());
+        throw new RuntimeException();
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/module/concert/application/facade/ConcertFacade.java
+++ b/src/main/java/kr/hhplus/be/server/module/concert/application/facade/ConcertFacade.java
@@ -10,6 +10,7 @@ import kr.hhplus.be.server.module.concert.domain.service.ConcertService;
 import kr.hhplus.be.server.module.concert.presentation.dto.AvailableSeatResponseDTO;
 import kr.hhplus.be.server.module.concert.presentation.dto.ConcertReservationResponseDTO;
 import kr.hhplus.be.server.module.concert.presentation.dto.ConcertResponseDTO;
+import kr.hhplus.be.server.module.externalApi.dataplatform.service.SendToDataPlatformService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -22,6 +23,7 @@ public class ConcertFacade implements ConcertUsecase {
 
     private final ConcertService concertService;
     private final WaitListTokenService waitListTokenService;
+    private final SendToDataPlatformService sendToDataPlatformService;
 
     @Override
     public List<ConcertResponseDTO> getConcertList() {
@@ -53,6 +55,9 @@ public class ConcertFacade implements ConcertUsecase {
 
         //예약 테이블에 row 추가
         ConcertReservation reservation = concertService.reserveSeatByUser(seat.getConcertId(), seatId, userId, expiredAt);
+
+        //좌석 예약 정보 데이터 플랫폼에 전달
+        sendToDataPlatformService.publishReservationEvent(userId, seatId); //seatId에 콘서트와 좌석 정보 모두 포함되어 있음
 
         return ConcertReservationResponseDTO.fromEntity(reservation);
     }

--- a/src/main/java/kr/hhplus/be/server/module/externalApi/dataplatform/dto/event/ReservationEvent.java
+++ b/src/main/java/kr/hhplus/be/server/module/externalApi/dataplatform/dto/event/ReservationEvent.java
@@ -1,0 +1,16 @@
+package kr.hhplus.be.server.module.externalApi.dataplatform.dto.event;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+public class ReservationEvent extends ApplicationEvent {
+    private final String userId;
+    private final long seatId;
+
+    public ReservationEvent(Object source, String userId, long seatId) {
+        super(source); // 이벤트 발생의 출처 (보통 this)
+        this.userId = userId;
+        this.seatId = seatId;
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/module/externalApi/dataplatform/listener/ReservationEventListener.java
+++ b/src/main/java/kr/hhplus/be/server/module/externalApi/dataplatform/listener/ReservationEventListener.java
@@ -1,0 +1,21 @@
+package kr.hhplus.be.server.module.externalApi.dataplatform.listener;
+
+import kr.hhplus.be.server.dataplatformModule.DataPlatform;
+import kr.hhplus.be.server.module.externalApi.dataplatform.dto.event.ReservationEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class ReservationEventListener {
+    private final DataPlatform dataPlatform;
+    @Async
+    @EventListener
+    public void handleReservationEvent(ReservationEvent event) {
+        dataPlatform.receivedReservationData(event);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/module/externalApi/dataplatform/service/SendToDataPlatformService.java
+++ b/src/main/java/kr/hhplus/be/server/module/externalApi/dataplatform/service/SendToDataPlatformService.java
@@ -1,0 +1,17 @@
+package kr.hhplus.be.server.module.externalApi.dataplatform.service;
+
+import kr.hhplus.be.server.module.externalApi.dataplatform.dto.event.ReservationEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SendToDataPlatformService {
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    public void publishReservationEvent(String userId, long seatId) {
+        ReservationEvent event = new ReservationEvent(this, userId, seatId);
+        applicationEventPublisher.publishEvent(event);
+    }
+}


### PR DESCRIPTION
### **커밋 링크**
- 데이터 플랫폼 mockAPI 호출 기능 추가: 5e26e65
- 트랜잭션 분리 설계 보고서 작성: 0c48ed1

> 보고서 링크를 잘못 연결했네요. 트랜잭션 관련 보고서는 GIT WIKI에 작성 되어 있습니다.
아래 주소 참고 부탁드립니다. 감사합니다

https://github.com/nacoon53/ticketing-service-api/wiki/8.-%ED%8A%B8%EB%9E%9C%EC%9E%AD%EC%85%98-%EB%B6%84%EB%A6%AC-%EC%84%A4%EA%B3%84(Feat.-MSA-%EC%84%A4%EA%B3%84)

---

### **리뷰 포인트(질문)**
- 이벤트 발행과 관련된 리스너와 퍼블리셔가 어떤 계층인지, 패키지를 어떻게 분류해야 할 지 잘 모르겠습니다.
- 분산 트랜잭션의 경우 오류 파악을 위해 현업에서는 로그 및 모니터링 체계를 어떻게 갖추는 지 궁금합니다.

---

### **이번주 KPT 회고**

### Keep
<!-- 유지해야 할 좋은 점 -->
인덱스가 저장되는 자료구조와 Saga 패턴에 대한 학습을 진행했고, 배운 내용을 혼자 말로 설명해보았다.

학습한 내용을 동료들과 충분히 이야기 해보면서 부족한 개념과 잘못 이해한 개념을 보충했다.
- MySQL 공식 문서에는 B-tree 구조를 사용한다고 되어있는데, 자료 구조의 B-tree가 아니고 Balanced Tree라는 뜻으로 실제로는 B+tree구조를 사용한다는 것을 안 게 제일 큰 수확이었다. (MySQL 8.0 기준)

### Problem
<!--개선이 필요한 점-->
개념은 배웠지만 역시나 아직 활용 부분에 있어서는 미숙하다

### Try
<!-- 새롭게 시도할 점 -->
패턴에 대한 예제코드 또는 다른 사람이 작성한 코드를 많이 봐야겠다.