### PR TITLE
Step20. 장애 대응 보고서 작성

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@
 ## 서비스 운영
 [부하 테스트 보고서](https://www.notion.so/9-1a76db2e3ea1801aa7daf235e9be3672#1a76db2e3ea180a9a2b1d02cd025083e)
 
+[장애 대응 문서](https://github.com/nacoon53/ticketing-service-api/wiki/10.-%EC%9E%A5%EC%95%A0-%EB%8C%80%EC%9D%91-%EB%AC%B8%EC%84%9C)
+
 ## API 명세서
 [API 명세서 - SwaggerHub 링크](https://app.swaggerhub.com/apis-docs/nakyoungoh/concert_reservation/1.0.0#/%EC%BD%98%EC%84%9C%ED%8A%B8%20API/getAvailableSeats)
 ![img.png](/docs/APISpec_v1.png)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,6 +93,17 @@ services:
       - KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS=kafka-1:29092,kafka-2:29093,kafka-3:29094
       - KAFKA_CLUSTERS_0_ZOOKEEPER=zookeeper:32181
 
+  grafana:
+    container_name: grafana
+    image: philhawthorne/docker-influxdb-grafana
+    ports:
+      - "3003:3003"
+      - "3004:8083"
+      - "8086:8086"
+    volumes:
+      - /path/for/influxdb:/var/lib/influxdb
+      - /path/for/grafana:/var/lib/grafana3
+
 networks:
   default:
     driver: bridge

--- a/src/main/java/kr/hhplus/be/server/module/auth/domain/service/WaitListTokenService.java
+++ b/src/main/java/kr/hhplus/be/server/module/auth/domain/service/WaitListTokenService.java
@@ -178,13 +178,15 @@ public class WaitListTokenService {
 
 
         for(Object obj : waitTokensByRedis) {
-            String token =  obj.toString().toString();
+            String token =  obj.toString();
             waitListTokenRedisManager.activateToken(token);
 
             //db에 저장된 토큰 상태값 변경
             WaitListToken waitListToken = waitListTokenRepository.findByToken(token);
-            waitListToken.setTokenStatusToActive();
-            waitListTokenRepository.save(waitListToken);
+            if(ObjectUtils.isNotEmpty(waitListToken)) { //2025-02-28 NPE 방지
+                waitListToken.setTokenStatusToActive();
+                waitListTokenRepository.save(waitListToken);
+            }
 
         }
     }


### PR DESCRIPTION
### **커밋 링크**
- 도커 구성에 Grafana 및 InfluxDB 추가: e2061ce
- 대기열 스케줄러에서 토큰 상태 변경 시 NPE 오류 수정: 3b989ff
- 장애 대응 보고서: 6887626


---

### **리뷰 포인트(질문)**
- 하나의 서비스에도 도커에는 여러 이미지 파일이 존재할 수 있는데요. 이 경우 적합한 이미지 파일을 어떻게 확인하고 사용하시나요?

---

### **이번주 KPT 회고**

### Keep
<!-- 유지해야 할 좋은 점 -->
점점 보고서 쓰는 게 나아지는 것 같다.
아직도 보고서를 작성할 때 어디서부터 시작해야 할지 막막하고 글쓰기가 어색하지만, 고난의 시간을 견디고 글을 완성하면 꽤 뿌듯하다.

### Problem
<!--개선이 필요한 점-->
이번에 Docker에 k6를 올려보려고 했지만, 설정 단계에서 자꾸 막혀 결국 로컬 환경에 k6를 설치해 진행했다.
Docker 사용에 더욱 익숙해질 필요가 있다.


### Try
<!-- 새롭게 시도할 점 -->
실제로 운영 되는 서비스를 올려서 직접 장애 상황을 겪고, 해결해 가는 과정을 문서화하고 싶다.